### PR TITLE
Add "breakout" command to create breakout rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Added
+
+* New command `breakout`. Allows splitting discussion into breakout rooms.
+
 ## v0.1.0 - 2020-10-24
 
 Initial version with the following commands:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Creates a breakout room. The user who requested the breakout room creation will
 automatically be invited to the room and made admin. The room will be created
 as non-public and non-encrypted.
 
-Other users can react to the breakout room creation response with a thumbs up to
+Other users can react to the breakout room creation response with any emoji reaction to
 get an invite to the room.
 
 Syntax:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ Bubo will automatically join rooms it is invited to.
 
 ### Commands
 
+#### `breakout`
+
+Creates a breakout room. The user who requested the breakout room creation will
+automatically be invited to the room and made admin. The room will be created
+as non-public and non-encrypted.
+
+Other users can react to the breakout room creation response with a thumbs up to
+get an invite to the room.
+
+Syntax:
+
+    breakout TOPIC
+    
+For example:
+
+    breakout How awesome is Bubo?
+    
+Any remaining text after `breakout` will be used as the room name.
+
+Note that while Bubo will stay in the breakout room itself, it will not maintain
+it in any way like the rooms created using the `rooms` command.
+
 #### `communities`
 
 Maintain communities.

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -107,7 +107,7 @@ class Command(object):
                 )
                 text = f"Breakout room for '{params[0]}' created!\n"
                 if breakout_room["alias"]:
-                    text += f"\n\nJoin via {breakout_room['alias']}.\n"
+                    text += f"\n\nJoin via #{breakout_room['alias']}:{self.config.server_name}.\n"
                 text += "\n\nReact to this message with a 👍 to get invited to the room."
                 if params[2] == "yes":
                     text += " Please note due to the room being encrypted, history will not be visible to users " \

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -87,7 +87,7 @@ class Command(object):
                     "Any remaining text after the `breakout` command will be used as the name of the room. " \
                     "The user requesting the breakout room will be automatically invited to the new room " \
                     "and made admin. " \
-                    "Other users can react to this message with a 👍 to " \
+                    "Other users can react to the bot response message with any emoji reaction to " \
                     "get invited to the room."
         if not self.args or self.args[0] == "help":
             await send_text_to_room(self.client, self.room.room_id, help_text)
@@ -100,7 +100,7 @@ class Command(object):
                 created_by=self.event.sender,
             )
             text = f"Breakout room '{name}' created!\n"
-            text += "\n\nReact to this message with a 👍 to get invited to the room."
+            text += "\n\nReact to this message with any emoji reaction to get invited to the room."
             event_id = await send_text_to_room(self.client, self.room.room_id, text)
             if event_id:
                 self.store.store_breakout_room(event_id, room_id)

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -115,9 +115,10 @@ class Command(object):
                 event_id = await send_text_to_room(self.client, self.room.room_id, text)
                 if event_id:
                     self.store.store_breakout_room(event_id, breakout_room["room_id"])
-                text = "*Error: failed to store breakout room data. The room was created, " \
-                       "but invites via reactions will not work."
-                await send_text_to_room(self.client, self.room.room_id, text)
+                else:
+                    text = "*Error: failed to store breakout room data. The room was created, " \
+                           "but invites via reactions will not work."
+                    await send_text_to_room(self.client, self.room.room_id, text)
                 return
         else:
             text = "Unknown subcommand! Try `breakout help`"

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -92,9 +92,9 @@ class Command(object):
         if not self.args or self.args[0] == "help":
             text = help_text
         elif self.args:
-            args = self.args[1:]
-            params = csv.reader([' '.join(args)], delimiter=" ")
+            params = csv.reader([' '.join(self.args)], delimiter=" ")
             params = [param for param in params][0]
+            logger.debug(f"Breakout room params: {params}")
             if len(params) != 3:
                 text = help_text
             else:

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -61,7 +61,9 @@ class Command(object):
 
     async def process(self):
         """Process the command"""
-        if self.command.startswith("communities"):
+        if self.command.startswith("breakout"):
+            await self._breakout()
+        elif self.command.startswith("communities"):
             await self._communities()
         elif self.command.startswith("help"):
             await self._show_help()

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -78,7 +78,7 @@ class Command(object):
         """Create a breakout room"""
         help_text = "Creates a breakout room. Usage:\n" \
                     "\n" \
-                    "breakout TOPIC PUBLIC(yes/no) ENCRYPTED(yes/no)\n" \
+                    "breakout TOPIC ENCRYPTED(yes/no) PUBLIC(yes/no)\n" \
                     "\n" \
                     "For example:\n" \
                     "\n" \

--- a/chat_functions.py
+++ b/chat_functions.py
@@ -27,12 +27,15 @@ async def invite_to_room(
                 command_room_id,
                 f"Failed to invite user {user_id} to room: {response.message} (code: {response.status_code})",
             )
+            logger.warning(f"Failed to invite user {user_id} to room: {response.message} "
+                           f"(code: {response.status_code})")
     elif command_room_id:
         await send_text_to_room(
             client,
             command_room_id,
             f"Invite for {room_alias or room_id} to {user_id} done!",
         )
+        logger.info(f"Invite for {room_alias or room_id} to {user_id} done!")
 
 
 async def send_text_to_room(

--- a/chat_functions.py
+++ b/chat_functions.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 # noinspection PyPackageRequirements
 from nio import (
-    SendRetryError, RoomInviteError, AsyncClient, ErrorResponse
+    SendRetryError, RoomInviteError, AsyncClient, ErrorResponse, RoomSendResponse
 )
 from markdown import markdown
 
@@ -89,9 +89,9 @@ async def send_text_to_room(
                 await send_text_to_room(client, room_id, message, notice, markdown_convert)
             else:
                 logger.warning(f"Failed to send message to {room_id} due to {response.status_code}")
-        try:
-            return response[2]["event_id"]
-        except Exception as ex:
-            logger.warning(f"Failed to get event_id from send_text_to_room: {ex}, response: {response}")
+        elif isinstance(response, RoomSendResponse):
+            return response.event_id
+        else:
+            logger.warning(f"Failed to get event_id from send_text_to_room, response: {response}")
     except SendRetryError:
         logger.exception(f"Unable to send message response to {room_id}")

--- a/chat_functions.py
+++ b/chat_functions.py
@@ -86,7 +86,7 @@ async def send_text_to_room(
         if isinstance(response, ErrorResponse):
             if response.status_code == "M_LIMIT_EXCEEDED":
                 time.sleep(3)
-                await send_text_to_room(client, room_id, message, notice, markdown_convert)
+                return await send_text_to_room(client, room_id, message, notice, markdown_convert)
             else:
                 logger.warning(f"Failed to send message to {room_id} due to {response.status_code}")
         elif isinstance(response, RoomSendResponse):

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from nio import (
     LoginError,
     LocalProtocolError,
     MegolmEvent,
+    UnknownEvent,
 )
 # noinspection PyPackageRequirements
 from aiohttp import (
@@ -69,6 +70,9 @@ async def main():
     client.add_event_callback(callbacks.invite, (InviteMemberEvent,))
     # noinspection PyTypeChecker
     client.add_event_callback(callbacks.decryption_failure, (MegolmEvent,))
+    # Nio doesn't currently have m.reaction events so we catch UnknownEvent for reactions and filter there
+    # noinspection PyTypeChecker
+    client.add_event_callback(callbacks.reaction, (UnknownEvent,))
 
     # Keep trying to reconnect on failure (with some time in-between)
     while True:

--- a/migrations/006.py
+++ b/migrations/006.py
@@ -1,0 +1,10 @@
+def forward(cursor):
+    cursor.execute("""
+        CREATE TABLE breakout_rooms (
+            id INTEGER PRIMARY KEY autoincrement,
+            event_id text,
+            room_id text
+        )
+    """)
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,3 @@ Markdown>=3.1.1
 PyYAML>=5.1.2
 python-slugify
 requests
-
-# Until 3.7.2+ released, to fix SSL regression
-aiohttp<3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ Markdown>=3.1.1
 PyYAML>=5.1.2
 python-slugify
 requests
+
+# Until 3.7.2+ released, to fix SSL regression
+aiohttp<3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 matrix-nio[e2e]>=0.8.0
 Markdown>=3.1.1
 PyYAML>=5.1.2
+python-slugify
 requests

--- a/rooms.py
+++ b/rooms.py
@@ -49,7 +49,7 @@ async def create_breakout_room(
     else:
         raise Exception(f"Could not create breakout room: {response.message}, {response.status_code}")
     await make_user_admin(room_id, created_by, client)
-    await invite_to_room(client, room_id, created_by, room_id)
+    await invite_to_room(client, room_id, created_by)
     return {
         "room_id": room_id,
         "alias": alias,

--- a/storage.py
+++ b/storage.py
@@ -74,6 +74,14 @@ class Storage(object):
         if room:
             return room[0]
 
+    def get_breakout_room_id(self, event_id: str):
+        results = self.cursor.execute("""
+            select room_id from breakout_rooms where event_id = ?;
+        """, (event_id,))
+        room = results.fetchone()
+        if room:
+            return room[0]
+
     def store_breakout_room(self, event_id: str, room_id: str):
         self.cursor.execute("""
             insert into breakout_rooms

--- a/storage.py
+++ b/storage.py
@@ -3,7 +3,7 @@ import logging
 from importlib import import_module
 from typing import Optional
 
-latest_db_version = 5
+latest_db_version = 6
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +73,14 @@ class Storage(object):
         room = results.fetchone()
         if room:
             return room[0]
+
+    def store_breakout_room(self, event_id: str, room_id: str):
+        self.cursor.execute("""
+            insert into breakout_rooms
+                (event_id, room_id) values 
+                (?, ?);
+        """, (event_id, room_id))
+        self.conn.commit()
 
     def store_community(self, name: str, alias: str, title: str):
         self.cursor.execute("""

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,10 @@
 import time
 
 
-async def with_ratelimit(client, method, *args):
+async def with_ratelimit(client, method, *args, **kwargs):
     func = getattr(client, method)
-    response = await func(*args)
+    response = await func(*args, **kwargs)
     if getattr(response, "status_code", None) == "M_LIMIT_EXCEEDED":
         time.sleep(3)
-        return with_ratelimit(client, method, *args)
+        return with_ratelimit(client, method, *args, **kwargs)
     return response


### PR DESCRIPTION
The user requesting the breakout room will be automatically invited to the new room
and made admin. If the room is public, an alias will be automatically created and posted to the room where the breakout command was issued. Other users can react to this message with a 👍 to get invited to the room. If the room is public, anyone can of course join via the alias.

TODO:
* [x] Implement invite on reaction
* [x] Consider alternative flow where user is asked about encryption and room visibility before creating room