### PR TITLE
Power levels configuration changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   overrides. By default, they will also be enforced on old rooms, unless
   `rooms.enforce_power_in_old_rooms` is set to `false`.
 
+### Fixed
+
+* Don't fail to start up if `matrix.user_token` is not set (but password is).
+
 ### Removed
 
 * Removed the `power_to_write` override in the `rooms` database table. Rooms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+* Default power levels can now be configured in config as `rooms.power_levels` (see
+  sample config file). If defined, they will be used in room creation power level
+  overrides. By default, they will also be enforced on old rooms, unless
+  `rooms.enforce_power_in_old_rooms` is set to `false`.
+
 ### Removed
 
 * Removed the `power_to_write` override in the `rooms` database table. Rooms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Removed
+
+* Removed the `power_to_write` override in the `rooms` database table. Rooms
+  can no longer for now have custom power levels enforced by Bubo on a per room basis.  
+
 ## v0.2.0 - 2020-10-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ commands). It will currently ensure the following details are correct:
   the database without an ID and restarting)
 * Ensure rooms marked as encrypted are encrypted
 * Ensure room power levels (see above "Room power levels") 
-* Ensure required power to write to a room (defaults to 0, but can be set in the database per room)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Same as without a subcommand, Bubo will tell you all about the rooms it maintain
 
 ### Room power levels
 
+#### User power
+
 Bubo can be picky on who can have power in a room. All rooms that it maintains (ie the rooms
 stored in it's database) will be checked on start-up and Bubo can be made to promote or demote
 users to their correct level, using the following rules:
@@ -153,6 +155,12 @@ promote but not demote users in the room. Users not in the room who have too muc
 will always be demoted.
 
 Currently it's not possible to override this on a per room basis but is likely to come.
+
+#### Room power defaults
+
+The sample config contains `room.power_levels` for the default power levels that
+Bubo will use for new rooms. By default, it will also enforce these power levels on
+old rooms, unless told not to.
 
 ### Room and community maintenance
 

--- a/bot_commands.py
+++ b/bot_commands.py
@@ -269,7 +269,7 @@ class Command(object):
                 else:
                     result, error = await ensure_room_exists(
                         (None, params[0], params[1], None, params[2], None, True if params[3] == "yes" else False,
-                         True if params[4] == "yes" else False, 0, ""),
+                         True if params[4] == "yes" else False, ""),
                         self.client,
                         self.store,
                         self.config,

--- a/config.py
+++ b/config.py
@@ -92,6 +92,9 @@ class Config(object):
         self.permissions_demote_users = self._get_cfg(["permissions", "demote_users"], default=False, required=False)
         self.permissions_promote_users = self._get_cfg(["permissions", "promote_users"], default=True, required=False)
 
+        # Rooms
+        self.rooms = self._get_cfg(["rooms"], default={}, required=False)
+
     def _get_cfg(
             self,
             path: List[str],
@@ -113,7 +116,7 @@ class Config(object):
             # If at any point we don't get our expected option...
             if config is None:
                 # Raise an error if it was required
-                if required or not default:
+                if required or default is False or default is None:
                     raise ConfigError(f"Config option {'.'.join(path)} is required")
 
                 # or return the default value

--- a/config.py
+++ b/config.py
@@ -64,8 +64,8 @@ class Config(object):
         if not re.match("@.*:.*", self.user_id):
             raise ConfigError("matrix.user_id must be in the form @name:domain")
 
-        self.user_token = self._get_cfg(["matrix", "user_token"])
-        self.user_password = self._get_cfg(["matrix", "user_password"])
+        self.user_token = self._get_cfg(["matrix", "user_token"], required=False, default=None)
+        self.user_password = self._get_cfg(["matrix", "user_password"], required=False, default=None)
         if not self.user_token and not self.user_password:
             raise ConfigError("Must supply either user token or password")
 

--- a/config.py
+++ b/config.py
@@ -64,8 +64,8 @@ class Config(object):
         if not re.match("@.*:.*", self.user_id):
             raise ConfigError("matrix.user_id must be in the form @name:domain")
 
-        self.user_token = self._get_cfg(["matrix", "user_token"], required=False, default=None)
-        self.user_password = self._get_cfg(["matrix", "user_password"], required=False, default=None)
+        self.user_token = self._get_cfg(["matrix", "user_token"], required=False, default="")
+        self.user_password = self._get_cfg(["matrix", "user_password"], required=False, default="")
         if not self.user_token and not self.user_password:
             raise ConfigError("Must supply either user token or password")
 

--- a/migrations/006.py
+++ b/migrations/006.py
@@ -6,5 +6,3 @@ def forward(cursor):
             room_id text
         )
     """)
-
-

--- a/migrations/007.py
+++ b/migrations/007.py
@@ -1,0 +1,42 @@
+def forward(cursor):
+    # Remove column 'power_to_write' from rooms
+    cursor.execute("""
+        CREATE TABLE rooms_backup (
+            id INTEGER PRIMARY KEY,
+            name text,
+            alias text,
+            room_id text null,
+            title text default '',
+            icon text default '',
+            encrypted integer,
+            public integer,
+            type text default ''
+        )
+    """)
+    cursor.execute("""
+        INSERT INTO rooms_backup SELECT id, name, alias, room_id, title, icon, encrypted, public, type 
+            FROM rooms
+    """)
+    cursor.execute("""
+        DROP TABLE rooms
+    """)
+    cursor.execute("""
+        CREATE TABLE rooms (
+            id INTEGER PRIMARY KEY autoincrement,
+            name text,
+            alias text constraint room_alias_unique_idx unique,
+            room_id text null constraint room_room_id_unique_idx unique,
+            title text default '',
+            icon text default '',
+            encrypted integer,
+            public integer,
+            type text default ''
+        )
+    """)
+    cursor.execute("""
+        INSERT INTO rooms SELECT id, name, alias, room_id, title, icon, encrypted, public, type 
+            FROM rooms_backup
+    """)
+    cursor.execute("""
+        DROP TABLE rooms_backup
+    """)

--- a/rooms.py
+++ b/rooms.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from copy import deepcopy
 
 from typing import Tuple, Optional, List, Dict
 
@@ -62,7 +63,7 @@ async def ensure_room_power_levels(
     Ensure room has correct power levels.
     """
     logger.debug(f"Ensuring power levels: {room_id}")
-    state = await client.room_get_state_event(room_id, "m.room.power_levels")
+    state = await with_ratelimit(client, "room_get_state_event", room_id=room_id, event_type="m.room.power_levels")
     users = state.content["users"].copy()
     member_ids = {member.user_id for member in members}
 
@@ -89,19 +90,21 @@ async def ensure_room_power_levels(
             if user in member_ids:
                 users[user] = 50
 
-    if state.content["users"] != users:
-        state.content["users"] = users
+    power_levels = config.rooms.get("power_levels") if config.rooms.get("enforce_power_in_old_rooms", True) else {}
+    new_power = deepcopy(state.content)
+    new_power.update(power_levels)
+    new_power["users"] = users
+
+    if state.content != new_power:
         logger.info(f"Updating room {room_id} power levels")
-        response = await client.room_put_state(
+        response = await with_ratelimit(
+            client,
+            "room_put_state",
             room_id=room_id,
             event_type="m.room.power_levels",
-            content=state.content,
+            content=new_power,
         )
         logger.debug(f"Power levels update response: {response}")
-        if isinstance(response, RoomPutStateError):
-            if response.status_code == "M_LIMIT_EXCEEDED":
-                time.sleep(3)
-                return ensure_room_power_levels(room_id, client, config, members)
 
 
 async def ensure_room_exists(
@@ -119,9 +122,6 @@ async def ensure_room_exists(
         state.append(
             EnableEncryptionBuilder().as_dict(),
         )
-    # power_level_override = {
-    #     "events_default": power_to_write,
-    # }
     # Check if room exists
     if not room_id:
         logger.info(f"Room '{alias}' ID unknown")
@@ -138,7 +138,7 @@ async def ensure_room_exists(
                 name=name,
                 topic=title,
                 initial_state=state,
-                # power_level_override=power_level_override,
+                power_level_override=config.rooms.get("power_levels"),
             )
             if getattr(response, "room_id", None):
                 room_id = response.room_id

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -63,7 +63,7 @@ rooms:
       "m.room.power_levels": 100
       "m.room.server_acl": 100
       "m.room.tombstone": 100
-    events_default": 0
+    events_default: 0
     invite: 0
     kick: 50
     redact: 50

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -48,6 +48,30 @@ permissions:
   # Promote users who should have more power in a room
   promote_users: true
 
+# Configuration for rooms maintained by Bubo.
+rooms:
+  # Default power levels. Bubo will ensure these are set for the rooms
+  # it maintains on creation and startup.
+  power_levels:
+    ban: 50
+    events:
+      "m.room.avatar": 50
+      "m.room.canonical_alias": 50
+      "m.room.encryption": 100
+      "m.room.history_visibility": 100
+      "m.room.name": 50
+      "m.room.power_levels": 100
+      "m.room.server_acl": 100
+      "m.room.tombstone": 100
+    events_default": 0
+    invite: 0
+    kick: 50
+    redact: 50
+    state_default: 50
+    users_default: 0
+  # Should bubo enforce the default power levels in old rooms as well?
+  enforce_power_in_old_rooms: true
+
 storage:
   # The path to the database
   database_filepath: "/data/bubo.db"

--- a/storage.py
+++ b/storage.py
@@ -3,7 +3,7 @@ import logging
 from importlib import import_module
 from typing import Optional
 
-latest_db_version = 6
+latest_db_version = 7
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Removed the `power_to_write` override

In `rooms` database table. Rooms can no longer for now have custom power levels enforced by Bubo on a per room basis.

In the future, plan is to add possibility to enforce any particular power levels per room though initially there will be default configuration that can be enforced.

Add configuration for room power level overrides

Default power levels can now be configured in config as `rooms.power_levels` (see sample config file). If defined, they will be used in room creation power level overrides. By default, they will also be enforced on old rooms, unless `rooms.enforce_power_in_old_rooms` is set to `false`.

