### PR TITLE
Add command `users`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   
 * Add command `power` to set power levels in a room where the bot has the 
   required power.
+  
+* Add command `users` to interact with an identity provider. Currently only Keycloak
+  is supported and the only functionality is to list usernames found in the configured
+  realm.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ ENCRYPTED and PUBLIC are either 'yes' or 'no'.
 
 Same as without a subcommand, Bubo will tell you all about the rooms it maintains.
 
+#### `users`
+
+Manage users of an identity provider.
+
+Currently [Keycloak](https://www.keycloak.org/) is the only identity provider supported.
+The `users` command requires `admin` level bot privileges and currently just lists the
+usernames in the configured realm. See `sample.config.yaml` for how to configure
+a Keycloak client.
+
+Future functionality will include registering users and sending them password reset
+emails, as some examples.
+
 ### Room power levels
 
 #### User power

--- a/config.py
+++ b/config.py
@@ -98,6 +98,9 @@ class Config(object):
         # Callbacks
         self.callbacks = self._get_cfg(["callbacks"], default={}, required=False)
 
+        # Users
+        self.users = self._get_cfg(["users"], default={}, required=False)
+
     def _get_cfg(
             self,
             path: List[str],

--- a/help_strings.py
+++ b/help_strings.py
@@ -1,0 +1,4 @@
+HELP_USERS = """List or manage users.
+
+Without any subcommands, lists users. Actually that's the only thing it does for now :P
+"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 matrix-nio[e2e]>=0.8.0
 Markdown>=3.1.1
+python-keycloak>=0.24.0
 PyYAML>=5.1.2
 requests

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -48,6 +48,24 @@ permissions:
   # Promote users who should have more power in a room
   promote_users: true
 
+# Configuration related to user management.
+# Currently Keycloak is the only provider.
+users:
+  provider:
+    # Future expansion, this is not checked yet for anything
+    # Please note you need to create a client in your keycloak realm, with the following:
+    # - client protocol: openid-connect
+    # - access type: confidential
+    # - service accounts enabled: true
+    # - service account roles -> client roles -> realm management: manage-users
+    # - service account roles -> client roles -> realm management: query-groups
+    # Then copy the credentials client secret here in 'client_secret_key'
+    type: keycloak
+    url: "http://keycloak.domain.tld/auth/"
+    # Define your realm
+    realm_name: "master"
+    client_secret_key: "client-secret"
+
 # Configuration for rooms maintained by Bubo.
 rooms:
   # Default power levels. Bubo will ensure these are set for the rooms

--- a/users.py
+++ b/users.py
@@ -1,0 +1,24 @@
+from typing import List, Dict
+
+# noinspection PyPackageRequirements
+from keycloak import KeycloakAdmin
+
+from config import Config
+
+
+def get_admin_client(config: Config) -> KeycloakAdmin:
+    params = {
+        "server_url": config.users["provider"]["url"],
+        "realm_name": config.users["provider"]["realm_name"],
+        "client_secret_key": config.users["provider"]["client_secret_key"],
+        "verify": True,
+    }
+    return KeycloakAdmin(**params)
+
+
+async def list_users(config: Config) -> List[Dict]:
+    if not config.users.get('provider'):
+        return []
+    keycloak_admin = get_admin_client(config)
+    users = keycloak_admin.get_users({})
+    return users


### PR DESCRIPTION
Interacts with an identity provider. Currently only Keycloak is supported and the only functionality is to list usernames found in the configured realm.